### PR TITLE
Add domain README files and metadata headers

### DIFF
--- a/GAIA-Platforms/Domains/AEROSPACE/README.md
+++ b/GAIA-Platforms/Domains/AEROSPACE/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – AEROSPACE Domain
+
+## Introduction
+
+The AEROSPACE domain within GAIA-Platforms focuses on the development and implementation of advanced aerospace systems dedicated to both civil and military aviation. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and performance of aerospace operations.
+
+## Purpose
+
+The purpose of the AEROSPACE domain is to provide a structured framework for the development of aerospace systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of aerospace initiatives.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/ASTRO-EXPLORATION/README.md
+++ b/GAIA-Platforms/Domains/ASTRO-EXPLORATION/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – ASTRO-EXPLORATION Domain
+
+## Introduction
+
+The ASTRO-EXPLORATION domain within GAIA-Platforms focuses on the development and implementation of advanced systems dedicated to the exploration of outer space. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and sustainability of space exploration missions.
+
+## Purpose
+
+The purpose of the ASTRO-EXPLORATION domain is to provide a structured framework for the development of space exploration systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of space exploration initiatives.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/CIVIL/README.md
+++ b/GAIA-Platforms/Domains/CIVIL/README.md
@@ -1,0 +1,19 @@
+# GAIA-Platforms – CIVIL Domain
+
+## Introduction
+
+The CIVIL domain within GAIA-Platforms focuses on the development and implementation of sustainable, advanced aerospace systems dedicated to civil aviation. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and environmental sustainability of civil aviation.
+
+## Purpose
+
+The purpose of the CIVIL domain is to provide a structured framework for the development of civil aerospace systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of civil aviation initiatives.
+
+## Relevant Documents
+
+- [Aerospace Information Sustainability High-Tech Framework (AISF-HT)](AISF-HT.md)
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/COMMON-INFRA/README.md
+++ b/GAIA-Platforms/Domains/COMMON-INFRA/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – COMMON-INFRA Domain
+
+## Introduction
+
+The COMMON-INFRA domain within GAIA-Platforms focuses on the foundational infrastructure and shared services that support the various domains within the GAIA ecosystem. This includes the integration of cross-domain technologies, standardized protocols, and common frameworks to ensure seamless interoperability and efficient operations.
+
+## Purpose
+
+The purpose of the COMMON-INFRA domain is to provide a robust and scalable infrastructure that supports the diverse needs of the GAIA-Platforms. This includes the development and maintenance of shared services, common frameworks, and standardized protocols that enable efficient and effective collaboration across different domains.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/DRONES/README.md
+++ b/GAIA-Platforms/Domains/DRONES/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – DRONES Domain
+
+## Introduction
+
+The DRONES domain within GAIA-Platforms focuses on the development and implementation of advanced unmanned aerial systems (UAS) dedicated to various applications, including civil, commercial, and defense. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and performance of drone operations.
+
+## Purpose
+
+The purpose of the DRONES domain is to provide a structured framework for the development of unmanned aerial systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of drone initiatives.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/SPACE/README.md
+++ b/GAIA-Platforms/Domains/SPACE/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – SPACE Domain
+
+## Introduction
+
+The SPACE domain within GAIA-Platforms focuses on the development and implementation of advanced space systems dedicated to interplanetary exploration and transportation. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and sustainability of space operations.
+
+## Purpose
+
+The purpose of the SPACE domain is to provide a structured framework for the development of space systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of space initiatives.
+
+## Relevant Documents
+
+- [SD-COATFI-SPACE Framework Definition](../../GAIA-SPACE/SD-COATFI-SPACE.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/SUPPLY/README.md
+++ b/GAIA-Platforms/Domains/SUPPLY/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – SUPPLY Domain
+
+## Introduction
+
+The SUPPLY domain within GAIA-Platforms focuses on the development and implementation of advanced supply chain systems dedicated to aerospace and related industries. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, reliability, and sustainability of supply chain operations.
+
+## Purpose
+
+The purpose of the SUPPLY domain is to provide a structured framework for the development of supply chain systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of supply chain initiatives.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/Domains/URBAN-MOBILITY/README.md
+++ b/GAIA-Platforms/Domains/URBAN-MOBILITY/README.md
@@ -1,0 +1,21 @@
+# GAIA-Platforms – URBAN-MOBILITY Domain
+
+## Introduction
+
+The URBAN-MOBILITY domain within GAIA-Platforms focuses on the development and implementation of advanced urban mobility systems. This domain encompasses a wide range of technologies and methodologies aimed at enhancing the efficiency, safety, and sustainability of urban transportation.
+
+## Purpose
+
+The purpose of the URBAN-MOBILITY domain is to provide a structured framework for the development of urban mobility systems. This includes the integration of advanced technologies, modular components, and sustainable practices to ensure the long-term viability and success of urban transportation initiatives.
+
+## Relevant Documents
+
+- [GAIA-AIR CD-COATFI-AERODCP Overview](../../GAIA-AIR/CD-COATFI-AERODCP.md)
+- [GenAI Proposal Status Disclaimer](../../GAIA-AIR/GenAI-Proposal-Status-Disclaimer.md)
+- [COAFI Information Code Index (INFOCODE-INDEX)](../../COAFI-APP/INFOCODE-INDEX.md)
+- [GAIA-AIR-ESSENTIALS Domains](../../GAIA-AIR/GAIA-AIR-ESSENTIALS-Domains.md)
+- [Document Parts Overview (GP 0–12)](../../COAFI-APP/GP-0-12.md)
+- [Specific Document Library Placeholder Links](../../COAFI-APP/Specific-Document-Library-Placeholder-Links.md)
+- [AMPEL360XWLRGA Aircraft Design Framework](../../GAIA-AIR/AMPEL360XWLRGA.md)
+- [ATA Detailed Breakdown for AMPEL360XWLRGA](../../GAIA-AIR/ATA-Detailed-Breakdown.md)
+- [ELPACK Tables (Engineering Logical Packets)](../../GAIA-AIR/ELPACK-Tables.md)

--- a/GAIA-Platforms/GAIA-AIR/CD-COATFI-AERODCP.md
+++ b/GAIA-Platforms/GAIA-AIR/CD-COATFI-AERODCP.md
@@ -1,0 +1,38 @@
+---
+title: "GAIA-AIR CD-COATFI-AERODCP Core Overview"
+version: "0.9-DRAFT"
+status: "Preliminary (GenAI generated, pending SME validation)"
+author: "GAIA-Platforms Initiative"
+tags: [Civil Aerospace, Sustainability, Modular Systems, Ethical AI, COAFI]
+last_updated: "2025-04-26"
+related_documents:
+  - "../GP-FD/ToC-GP-FD.md"
+  - "../GP-AM/ToC-GP-AM.md"
+---
+
+# GAIA-AIR – CD-COATFI-AERODCP Framework
+
+> **Civil-Dedicated, Component-Oriented, Advanced-Technology-First Implementation**
+
+A technology-first strategy for aerospace systems development, prioritizing **civil aviation innovation**, **modular sustainability**, and **commercial regenerative pathways** within the GAIA Platforms vision.
+
+---
+
+## 📂 Core Documentation
+- [CD-COATFI-AERODCP Specification](https://github.com/Robbbo-T/Robbbo-T/blob/main/GAIA-AIR/CD-COATFI-AERODCP.md)
+
+---
+
+## 🎯 Purpose
+
+- **Civil-Centric Design:** Architect aerospace platforms with civil aviation as the foundational domain.
+- **Modular Components:** Enable standardized, interoperable aerospace subsystems.
+- **Advanced-Technology Prioritization:** Integrate cutting-edge propulsion, energy, and information systems.
+- **Commercial Spin-Off Readiness:** Design pathways for commercial adaptation and scalability.
+- **Sustainability Alignment:** Ensure long-term environmental and informational sustainability across programs.
+
+---
+
+# 🧭 Navigation
+- [GAIA AIR Project Overview](../README.md)
+- [GAIA Platforms Canonical Index](../../GAIA-Platforms/README.md)

--- a/GAIA-Platforms/GAIA-GREENTECH/README.md
+++ b/GAIA-Platforms/GAIA-GREENTECH/README.md
@@ -1,3 +1,15 @@
+---
+title: "GAIA-GREENTECH"
+version: "1.0"
+status: "Active"
+author: "GAIA-Platforms Initiative"
+tags: [Green Technology, Sustainability, Modular Systems, Ethical AI, COAFI]
+last_updated: "2025-04-26"
+related_documents:
+  - "../GP-FD/ToC-GP-FD.md"
+  - "../GP-AM/ToC-GP-AM.md"
+---
+
 # GAIA-GREENTECH
 
 **GAIA-GREENTECH** is the division dedicated to clean technologies and energy systems driving environmental stewardship across all domains.

--- a/GAIA-Platforms/GAIA-SPACE/README.md
+++ b/GAIA-Platforms/GAIA-SPACE/README.md
@@ -1,3 +1,15 @@
+---
+title: "GAIA-SPACE"
+version: "1.0"
+status: "Active"
+author: "GAIA-Platforms Initiative"
+tags: [Space Exploration, Sustainability, Modular Systems, Ethical AI, COAFI]
+last_updated: "2025-04-26"
+related_documents:
+  - "../GP-FD/ToC-GP-FD.md"
+  - "../GP-AM/ToC-GP-AM.md"
+---
+
 # GAIA-SPACE
 
 **GAIA-SPACE** is the division dedicated to interplanetary exploration and transportation platforms, emphasizing ethical expansion and sustainable practices.

--- a/GAIA-Platforms/README.md
+++ b/GAIA-Platforms/README.md
@@ -1,3 +1,15 @@
+---
+title: "GAIA-Platforms"
+version: "1.0"
+status: "Active"
+author: "GAIA-Platforms Initiative"
+tags: [Aerospace, Sustainability, Modular Systems, Ethical AI, COAFI]
+last_updated: "2025-04-26"
+related_documents:
+  - "../GP-FD/ToC-GP-FD.md"
+  - "../GP-AM/ToC-GP-AM.md"
+---
+
 # GAIA-Platforms
 
 ## Introduction


### PR DESCRIPTION
Add README.md files for each domain within GAIA-Platforms to provide structured documentation and relevant links.

* **CIVIL Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **AEROSPACE Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **SPACE Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **COMMON-INFRA Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **SUPPLY Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **DRONES Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **URBAN-MOBILITY Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **ASTRO-EXPLORATION Domain**
  - Create `README.md` with introduction, purpose, and relevant document links.

* **Metadata Headers**
  - Add metadata headers in YAML format to `GAIA-AIR/CD-COATFI-AERODCP.md`, `GAIA-GREENTECH/README.md`, `GAIA-SPACE/README.md`, and `GAIA-Platforms/README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Robbbo-T/GAIA-Platforms/pull/5?shareId=e6ba1873-0877-4227-bcb9-072315c4fa77).

## Summary by Sourcery

Add domain-specific README files and introduce metadata headers to documentation.

Documentation:
- Create README files for the AEROSPACE, ASTRO-EXPLORATION, CIVIL, COMMON-INFRA, DRONES, SPACE, SUPPLY, and URBAN-MOBILITY domains.
- Add YAML metadata headers to several existing and new documentation files.
- Add a new overview document for the CD-COATFI-AERODCP framework.